### PR TITLE
httpd config: Add X-Forwarded-For to our LogFormat

### DIFF
--- a/files/etc/httpd/conf/httpd.conf
+++ b/files/etc/httpd/conf/httpd.conf
@@ -189,7 +189,7 @@ LogLevel warn
     # The following directives define some format nicknames for use with
     # a CustomLog directive (see below).
     #
-    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h (for %{X-Forwarded-For}i) %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
     LogFormat "%h %l %u %t \"%r\" %>s %b" common
 
     <IfModule logio_module>


### PR DESCRIPTION
For debugging and security response, we need to be able to know the original requestor's IP, not just the Traefik IP handling the request. This adds the content of the X-Forwarded-For header to the combined LogFormat, which is what we pipe out.

If there is no content, Apache will log a "-"; there is no impact to images that directly face the Internet without being behind a proxy.