### PR TITLE
httpd config: Remove X-Forwarded-For from LogFormat

### DIFF
--- a/files/etc/httpd/conf/httpd.conf
+++ b/files/etc/httpd/conf/httpd.conf
@@ -189,7 +189,7 @@ LogLevel warn
     # The following directives define some format nicknames for use with
     # a CustomLog directive (see below).
     #
-    LogFormat "%h (for %{X-Forwarded-For}i) %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
     LogFormat "%h %l %u %t \"%r\" %>s %b" common
 
     <IfModule logio_module>


### PR DESCRIPTION
This reverts commit 63175c130ddaefe94e6d618e7456622051019e36.

Trying to debug an outage that may have been caused by it.